### PR TITLE
HL-Scala-API :: added matriculationAccess as defined in the API-ref

### DIFF
--- a/product_code/hyperledger/api/src/main/scala/de/upb/cs/uc4/hyperledger/traits/ChaincodeActionsTrait.scala
+++ b/product_code/hyperledger/api/src/main/scala/de/upb/cs/uc4/hyperledger/traits/ChaincodeActionsTrait.scala
@@ -6,7 +6,7 @@ import de.upb.cs.uc4.hyperledger.exceptions.{InvalidCallException, TransactionEr
  * Trait to provide general access to all chaincode transactions.
  * Aggregates all specific ChaincodeAccess traits.
  */
-trait ChaincodeActionsTrait extends ChaincodeActionsTraitCourses {
+trait ChaincodeActionsTrait extends ChaincodeActionsTraitCourses with ChaincodeActionsTraitStudents {
 
   /**
    * Submits any transaction specified by transactionId.
@@ -33,6 +33,18 @@ trait ChaincodeActionsTrait extends ChaincodeActionsTraitCourses {
         this.validateParameterCount(transactionId, 2, params.toArray)
         this.updateCourseById(params.apply(0), params.apply(1))
       }
+      case "addMatriculationData" => {
+        this.validateParameterCount(transactionId, 1, params.toArray)
+        this.addMatriculationData(params.apply(0))
+      }
+      case "addEntryToMatriculationData" => {
+        this.validateParameterCount(transactionId, 3, params.toArray)
+        this.addEntryToMatriculationData(params.apply(0), params.apply(1), params.apply(2))
+      }
+      case "updateMatriculationData" => {
+        this.validateParameterCount(transactionId, 1, params.toArray)
+        this.updateMatriculationData(params.apply(0))
+      }
       case _ => throw InvalidCallException.CreateInvalidIDException(transactionId)
     }
   }
@@ -57,6 +69,10 @@ trait ChaincodeActionsTrait extends ChaincodeActionsTraitCourses {
       case "getAllCourses" => {
         this.validateParameterCount(transactionId, 0, params.toArray)
         this.getAllCourses()
+      }
+      case "getMatriculationData" => {
+        this.validateParameterCount(transactionId, 1, params.toArray)
+        this.getMatriculationData(params.apply(0))
       }
       case _ => throw InvalidCallException.CreateInvalidIDException(transactionId)
     }

--- a/product_code/hyperledger/api/src/main/scala/de/upb/cs/uc4/hyperledger/traits/ChaincodeActionsTraitCourses.scala
+++ b/product_code/hyperledger/api/src/main/scala/de/upb/cs/uc4/hyperledger/traits/ChaincodeActionsTraitCourses.scala
@@ -8,7 +8,31 @@ import org.hyperledger.fabric.gateway.Contract
  */
 trait ChaincodeActionsTraitCourses extends ChaincodeActionsTraitInternal {
 
-  val contract_course: Contract
+  def contract_course: Contract
+
+  /**
+    * Submits any transaction specified by transactionId.
+    *
+    * @param transactionId transactionId to submit
+    * @param params        parameters to pass to the transaction
+    * @throws Exception if chaincode throws an exception.
+    * @return success_state
+    */
+  @throws[Exception]
+  private def internalSubmitTransaction(transactionId: String, params: String*): Array[Byte] =
+    this.internalSubmitTransaction(contract_course, transactionId, params: _*)
+
+  /**
+    * Evaluates the transaction specified by transactionId.
+    *
+    * @param transactionId transactionId to evaluate
+    * @param params        parameters to pass to the transaction
+    * @throws Exception if chaincode throws an exception.
+    * @return success_state
+    */
+  @throws[Exception]
+  private def internalEvaluateTransaction(transactionId: String, params: String*): Array[Byte] =
+    this.internalEvaluateTransaction(contract_course, transactionId, params: _*)
 
   /**
    * Executes the "addCourse" query.
@@ -48,18 +72,6 @@ trait ChaincodeActionsTraitCourses extends ChaincodeActionsTraitInternal {
   }
 
   /**
-   * Submits any transaction specified by transactionId.
-   *
-   * @param transactionId transactionId to submit
-   * @param params        parameters to pass to the transaction
-   * @throws Exception if chaincode throws an exception.
-   * @return success_state
-   */
-  @throws[Exception]
-  def internalSubmitTransaction(transactionId: String, params: String*): Array[Byte] =
-    this.internalSubmitTransaction(contract_course, transactionId, params: _*)
-
-  /**
    * Executes the "getCourses" query.
    *
    * @throws Exception if chaincode throws an exception.
@@ -73,18 +85,6 @@ trait ChaincodeActionsTraitCourses extends ChaincodeActionsTraitInternal {
     if (!result.startsWith("[") || !result.endsWith("]")) throw TransactionErrorException("getAllCourses", 0, "Returned invalid structure: " + result)
     else return result
   }
-
-  /**
-   * Evaluates the transaction specified by transactionId.
-   *
-   * @param transactionId transactionId to evaluate
-   * @param params        parameters to pass to the transaction
-   * @throws Exception if chaincode throws an exception.
-   * @return success_state
-   */
-  @throws[Exception]
-  def internalEvaluateTransaction(transactionId: String, params: String*): Array[Byte] =
-    this.internalEvaluateTransaction(contract_course, transactionId, params: _*)
 
   /**
    * Executes the "getCourseById" query.

--- a/product_code/hyperledger/api/src/main/scala/de/upb/cs/uc4/hyperledger/traits/ChaincodeActionsTraitStudents.scala
+++ b/product_code/hyperledger/api/src/main/scala/de/upb/cs/uc4/hyperledger/traits/ChaincodeActionsTraitStudents.scala
@@ -1,0 +1,90 @@
+package de.upb.cs.uc4.hyperledger.traits
+
+import de.upb.cs.uc4.hyperledger.exceptions.TransactionErrorException
+import org.hyperledger.fabric.gateway.Contract
+
+/**
+ * Trait to provide explicit access to chaincode transactions regarding courses
+ */
+trait ChaincodeActionsTraitStudents extends ChaincodeActionsTraitInternal {
+
+  def contract_student: Contract
+
+  /**
+    * Submits any transaction specified by transactionId.
+    *
+    * @param transactionId transactionId to submit
+    * @param params        parameters to pass to the transaction
+    * @throws Exception if chaincode throws an exception.
+    * @return success_state
+    */
+  @throws[Exception]
+  private def internalSubmitTransaction(transactionId: String, params: String*): Array[Byte] =
+    this.internalSubmitTransaction(contract_student, transactionId, params: _*)
+
+  /**
+    * Evaluates the transaction specified by transactionId.
+    *
+    * @param transactionId transactionId to evaluate
+    * @param params        parameters to pass to the transaction
+    * @throws Exception if chaincode throws an exception.
+    * @return success_state
+    */
+  @throws[Exception]
+  private def internalEvaluateTransaction(transactionId: String, params: String*): Array[Byte] =
+    this.internalEvaluateTransaction(contract_student, transactionId, params: _*)
+
+  /**
+   * Executes the "addCourse" query.
+   *
+   * @param jSonMatriculationData Information about the matriculation to add.
+   * @throws Exception if chaincode throws an exception.
+   * @return Success_state
+   */
+  @throws[Exception]
+  final def addMatriculationData(jSonMatriculationData : String): String = {
+    wrapTransactionResult("addMatriculationData",
+      this.internalSubmitTransaction("addMatriculationData", jSonMatriculationData))
+  }
+
+  /**
+   * Submits the "deleteCourseById" query.
+   *
+   * @param matriculationId courseId to add entry to
+   * @param fieldOfStudy field of study the student enroled in
+   * @param semester the semester the student enrolled for
+   * @throws Exception if chaincode throws an exception.
+   * @return success_state
+   */
+  @throws[Exception]
+  final def addEntryToMatriculationData(matriculationId : String, fieldOfStudy : String, semester : String): String = {
+    wrapTransactionResult("addEntryToMatriculationData",
+      this.internalSubmitTransaction("addEntryToMatriculationData", matriculationId, fieldOfStudy, semester))
+  }
+
+  /**
+   * Submits the "updateCourseById" query.
+   *
+   * @param jSonMatriculationData matriculationInfo to update
+   * @throws Exception if chaincode throws an exception.
+   * @return success_state
+   */
+  @throws[Exception]
+  final def updateMatriculationData(jSonMatriculationData : String): String = {
+    wrapTransactionResult("updateMatriculationData",
+      this.internalSubmitTransaction("updateMatriculationData", jSonMatriculationData))
+  }
+
+  /**
+   * Executes the "getCourseById" query.
+   *
+   * @param matId matriculationId to get information
+   * @throws Exception if chaincode throws an exception.
+   * @return JSon Course Object
+   */
+  @throws[Exception]
+  final def getMatriculationData(matId: String): String = {
+    wrapTransactionResult("getMatriculationData",
+      this.internalEvaluateTransaction("getMatriculationData", matId))
+  }
+}


### PR DESCRIPTION
### Reason for this PR
- Provide Scala Access to Matriculation Actions on chaincode

### Changes in this PR
- Add Trait for matriculation Actions
- Provide access to matriculation Actions via ChaincodeConnection object
