### PR TITLE
Add optional query parameters to GET users

### DIFF
--- a/product_code/lagom/authentication_service/impl/src/test/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceSpec.scala
+++ b/product_code/lagom/authentication_service/impl/src/test/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceSpec.scala
@@ -141,11 +141,11 @@ class AuthenticationServiceSpec extends AsyncWordSpec
 
 class UserServiceStub(deletionStub: ProducerStub[JsonUsername]) extends UserService {
 
-  override def getAllUsers: ServiceCall[NotUsed, GetAllUsersResponse] = ServiceCall { _ => Future.successful(null) }
+  override def getAllUsers(usernames: Option[String]): ServiceCall[NotUsed, GetAllUsersResponse] = ServiceCall { _ => Future.successful(null) }
 
   override def deleteUser(username: String): ServiceCall[NotUsed, Done] = ServiceCall { _ => Future.successful(Done) }
 
-  override def getAllStudents: ServiceCall[NotUsed, Seq[Student]] = ServiceCall { _ => Future.successful(Seq()) }
+  override def getAllStudents(usernames: Option[String]): ServiceCall[NotUsed, Seq[Student]] = ServiceCall { _ => Future.successful(Seq()) }
 
   override def addStudent(): ServiceCall[PostMessageStudent, Student] = ServiceCall { _ => Future.successful(null) }
 
@@ -153,7 +153,7 @@ class UserServiceStub(deletionStub: ProducerStub[JsonUsername]) extends UserServ
 
   override def updateStudent(username: String): ServiceCall[Student, Done] = ServiceCall { _ => Future.successful(Done) }
 
-  override def getAllLecturers: ServiceCall[NotUsed, Seq[Lecturer]] = ServiceCall { _ => Future.successful(Seq()) }
+  override def getAllLecturers(usernames: Option[String]): ServiceCall[NotUsed, Seq[Lecturer]] = ServiceCall { _ => Future.successful(Seq()) }
 
   override def addLecturer(): ServiceCall[PostMessageLecturer, Lecturer] = ServiceCall { _ => Future.successful(null) }
 
@@ -161,7 +161,7 @@ class UserServiceStub(deletionStub: ProducerStub[JsonUsername]) extends UserServ
 
   override def updateLecturer(username: String): ServiceCall[Lecturer, Done] = ServiceCall { _ => Future.successful(Done) }
 
-  override def getAllAdmins: ServiceCall[NotUsed, Seq[Admin]] = ServiceCall { _ => Future.successful(Seq()) }
+  override def getAllAdmins(usernames: Option[String]): ServiceCall[NotUsed, Seq[Admin]] = ServiceCall { _ => Future.successful(Seq()) }
 
   override def addAdmin(): ServiceCall[PostMessageAdmin, Admin] = ServiceCall { _ => Future.successful(null) }
 

--- a/product_code/lagom/user_service/CHANGELOG.md
+++ b/product_code/lagom/user_service/CHANGELOG.md
@@ -1,7 +1,8 @@
 # [v.0.5.1 WIP](https://github.com/upb-uc4/University-Credits-4.0/compare/v0.5.0...user-v0.5.1) (2020-XX-XX)
 ## Feature
 - Added predefined standard exceptions to CustomException
-- Add functionality that fetching a user returns less personal info, when invoked by a non-Admin that is not the user to fetch
+- Added functionality that fetching a user returns less personal info, when invoked by a non-Admin that is not the user to fetch
+- Added query parameter "usernames" to getAllUsers, getAllStudents, getAllLecturers, getAllAdmins to filter with
 ## Refactor
 - Changed exceptions to use these standard exceptions whereever possible
 ## Bugfix

--- a/product_code/lagom/user_service/api/src/main/scala/de/upb/cs/uc4/user/api/UserService.scala
+++ b/product_code/lagom/user_service/api/src/main/scala/de/upb/cs/uc4/user/api/UserService.scala
@@ -24,7 +24,7 @@ trait UserService extends UC4Service {
   // USER
 
   /** Get all users from the database */
-  def getAllUsers: ServiceCall[NotUsed, GetAllUsersResponse]
+  def getAllUsers(usernames: Option[String]): ServiceCall[NotUsed, GetAllUsersResponse]
 
   /** Delete a users from the database */
   def deleteUser(username: String): ServiceCall[NotUsed, Done]
@@ -32,7 +32,7 @@ trait UserService extends UC4Service {
   // STUDENT
 
   /** Get all students from the database */
-  def getAllStudents: ServiceCall[NotUsed, Seq[Student]]
+  def getAllStudents(usernames: Option[String]): ServiceCall[NotUsed, Seq[Student]]
 
   /** Add a new student to the database */
   def addStudent(): ServiceCall[PostMessageStudent, Student]
@@ -46,7 +46,7 @@ trait UserService extends UC4Service {
   // LECTURER
 
   /** Get all lecturers from the database */
-  def getAllLecturers: ServiceCall[NotUsed, Seq[Lecturer]]
+  def getAllLecturers(usernames: Option[String]): ServiceCall[NotUsed, Seq[Lecturer]]
 
   /** Add a new lecturer to the database */
   def addLecturer(): ServiceCall[PostMessageLecturer, Lecturer]
@@ -60,7 +60,7 @@ trait UserService extends UC4Service {
   // ADMIN
 
   /** Get all admins from the database */
-  def getAllAdmins: ServiceCall[NotUsed, Seq[Admin]]
+  def getAllAdmins(usernames: Option[String]): ServiceCall[NotUsed, Seq[Admin]]
 
   /** Add a new admin to the database */
   def addAdmin(): ServiceCall[PostMessageAdmin, Admin]
@@ -95,7 +95,7 @@ trait UserService extends UC4Service {
     import Service._
     super.descriptor
       .addCalls(
-        restCall(Method.GET, pathPrefix + "/users", getAllUsers _),
+        restCall(Method.GET, pathPrefix + "/users?usernames", getAllUsers _),
         restCall(Method.DELETE, pathPrefix + "/users/:username", deleteUser _),
         restCall(Method.OPTIONS, pathPrefix + "/users", allowedGet _),
         restCall(Method.OPTIONS, pathPrefix + "/users/:username", allowedDelete _),
@@ -103,21 +103,21 @@ trait UserService extends UC4Service {
         restCall(Method.GET, pathPrefix + "/role/:username", getRole _),
         restCall(Method.OPTIONS, pathPrefix + "/role/:username", allowedGet _),
 
-        restCall(Method.GET, pathPrefix + "/students", getAllStudents _),
+        restCall(Method.GET, pathPrefix + "/students?usernames", getAllStudents _),
         restCall(Method.POST, pathPrefix + "/students", addStudent _),
         restCall(Method.GET, pathPrefix + "/students/:username", getStudent _),
         restCall(Method.PUT, pathPrefix + "/students/:username", updateStudent _),
         restCall(Method.OPTIONS, pathPrefix + "/students/:username", allowedGetPut _),
         restCall(Method.OPTIONS, pathPrefix + "/students", allowedGetPost _),
 
-        restCall(Method.GET, pathPrefix + "/lecturers", getAllLecturers _),
+        restCall(Method.GET, pathPrefix + "/lecturers?usernames", getAllLecturers _),
         restCall(Method.POST, pathPrefix + "/lecturers", addLecturer _),
         restCall(Method.GET, pathPrefix + "/lecturers/:username", getLecturer _),
         restCall(Method.PUT, pathPrefix + "/lecturers/:username", updateLecturer _),
         restCall(Method.OPTIONS, pathPrefix + "/lecturers/:username", allowedGetPut _),
         restCall(Method.OPTIONS, pathPrefix + "/lecturers", allowedGetPost _),
 
-        restCall(Method.GET, pathPrefix + "/admins", getAllAdmins _),
+        restCall(Method.GET, pathPrefix + "/admins?usernames", getAllAdmins _),
         restCall(Method.POST, pathPrefix + "/admins", addAdmin _),
         restCall(Method.GET, pathPrefix + "/admins/:username", getAdmin _),
         restCall(Method.PUT, pathPrefix + "/admins/:username", updateAdmin _),

--- a/product_code/lagom/user_service/impl/src/test/scala/de/upb/cs/uc4/user/impl/UserServiceSpec.scala
+++ b/product_code/lagom/user_service/impl/src/test/scala/de/upb/cs/uc4/user/impl/UserServiceSpec.scala
@@ -15,7 +15,7 @@ import de.upb.cs.uc4.shared.client.exceptions.CustomException
 import de.upb.cs.uc4.user.api.UserService
 import de.upb.cs.uc4.user.model.post.{PostMessageAdmin, PostMessageLecturer, PostMessageStudent}
 import de.upb.cs.uc4.user.model.user.{Admin, Lecturer, Student}
-import de.upb.cs.uc4.user.model.{Address, JsonUsername, Role}
+import de.upb.cs.uc4.user.model.{Address, GetAllUsersResponse, JsonUsername, Role}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers
@@ -84,7 +84,7 @@ class UserServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll
 
     "get all users with default users" in {
       eventually(timeout(Span(2, Minutes))) {
-        client.getAllUsers.handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        client.getAllUsers(None).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
 
           answer.admins should have size 1
           answer.lecturers should have size 1
@@ -96,7 +96,7 @@ class UserServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll
     "add a student" in {
       client.addStudent().handleRequestHeader(addAuthorizationHeader("admin")).invoke(PostMessageStudent(authenticationUser, student0))
       eventually(timeout(Span(2, Minutes))) {
-        client.getAllStudents.handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        client.getAllStudents(None).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
           answer should contain(student0)
         }
       }
@@ -105,7 +105,7 @@ class UserServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll
     "add a lecturer" in {
       client.addLecturer().handleRequestHeader(addAuthorizationHeader("admin")).invoke(PostMessageLecturer(authenticationUser, lecturer0))
       eventually(timeout(Span(2, Minutes))) {
-        client.getAllLecturers.handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        client.getAllLecturers(None).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
           answer should contain(lecturer0)
         }
       }
@@ -114,7 +114,7 @@ class UserServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll
     "add an admin" in {
       client.addAdmin().handleRequestHeader(addAuthorizationHeader("admin")).invoke(PostMessageAdmin(authenticationUser, admin0))
       eventually(timeout(Span(2, Minutes))) {
-        client.getAllAdmins.handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        client.getAllAdmins(None).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
           answer should contain(admin0)
         }
       }
@@ -160,6 +160,47 @@ class UserServiceSpec extends AsyncWordSpec with Matchers with BeforeAndAfterAll
     "fetch the public information of an Admin as a lecturer" in {
       client.getAdmin(admin0.username).handleRequestHeader(addAuthorizationHeader("lecturer")).invoke().map { answer =>
         answer should ===(admin0.toPublic)
+      }
+    }
+
+    "fetch the public information of all specified Students, as a non-Admin" in {
+      client.getAllStudents(Some(student0.username)).handleRequestHeader(addAuthorizationHeader("student")).invoke().map { answer =>
+        answer should contain theSameElementsAs Seq(student0.toPublic)
+      }
+    }
+    "fetch the public information of all specified Lecturers, as a non-Admin" in {
+      client.getAllLecturers(Some(lecturer0.username)).handleRequestHeader(addAuthorizationHeader("student")).invoke().map { answer =>
+        answer should contain theSameElementsAs Seq(lecturer0.toPublic)
+      }
+    }
+    "fetch the public information of all specified Admins, as a non-Admin" in {
+      client.getAllAdmins(Some(admin0.username)).handleRequestHeader(addAuthorizationHeader("student")).invoke().map { answer =>
+        answer should contain theSameElementsAs Seq(admin0.toPublic)
+      }
+    }
+    "fetch the information of all specified Students, as an Admin" in {
+      client.getAllStudents(Some(student0.username)).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        answer should contain theSameElementsAs Seq(student0)
+      }
+    }
+    "fetch the information of all specified Lecturers, as an Admin" in {
+      client.getAllLecturers(Some(lecturer0.username)).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        answer should contain theSameElementsAs Seq(lecturer0)
+      }
+    }
+    "fetch the information of all specified Admins, as an Admin" in {
+      client.getAllAdmins(Some(admin0.username)).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        answer should contain theSameElementsAs Seq(admin0)
+      }
+    }
+    "fetch the public information of all specified Users, as a non-Admin" in {
+      client.getAllUsers(Some(student0.username+","+ lecturer0.username +","+admin0.username)).handleRequestHeader(addAuthorizationHeader("student")).invoke().map { answer =>
+        answer should ===(GetAllUsersResponse(Seq(student0.toPublic), Seq(lecturer0.toPublic), Seq(admin0.toPublic)))
+      }
+    }
+    "fetch the information of all specified Users, as a non-Admin" in {
+      client.getAllUsers(Some(student0.username+","+ lecturer0.username +","+admin0.username)).handleRequestHeader(addAuthorizationHeader("admin")).invoke().map { answer =>
+        answer should ===(GetAllUsersResponse(Seq(student0), Seq(lecturer0), Seq(admin0)))
       }
     }
 


### PR DESCRIPTION
### Reason for this PR
- Multiple single queries were needed in order to find the names of e.g. multiple lecturers, when fetching names for a list of courses.

### Changes in this PR
- Added query parameter "usernames" to getAllUsers, getAllStudents, getAllLecturers, getAllAdmins to filter
