### PR TITLE
Remove LaTeX from markdown, as github does not properly display them

### DIFF
--- a/product_test/test_documentation/validation/authentication-management.md
+++ b/product_test/test_documentation/validation/authentication-management.md
@@ -2,11 +2,11 @@
 Every invalid equivalence class returns an error. Every valid class returns an empty sequence.
 
 ## AuthenticationUser
-$\textsf{validCharactersUsername} := \textsf{Letters} \cup \textsf{Digits} \cup \{\textsf{'-'}\}$
+*validCharactersUsername* := Letters ∪ Digits ∪ {'-'}
 ### username (String)
-- vUsername1: username.length $\in$ [4,16] AND username has only characters defined in $\textsf{validCharactersUsername}$
-- iUsername1: username.length $\notin$ [4,16]
-- iUsername2: username contains characters not defined in $\textsf{validCharactersUsername}$
+- vUsername1: username.length ∈ [4, 16] AND username has only characters defined in *validCharactersUsername*
+- iUsername1: username.length ∉ [4, 16]
+- iUsername2: username contains characters not defined in *validCharactersUsername*
 
 ### password (String)
 - vPassword1: password.length > 0

--- a/product_test/test_documentation/validation/course-management.md
+++ b/product_test/test_documentation/validation/course-management.md
@@ -7,46 +7,46 @@ Every invalid equivalence class returns an error. Every valid class returns an e
 Not validated, as it is a generated UUID.
 
 ### courseName (String)
-- vCourseName1: courseName.length $\in$ [1,100]
+- vCourseName1: courseName.length ∈ [1, 100]
 - iCourseName1: courseName is the empty String
-- iCourseName2: courseName.length $>100$
+- iCourseName2: courseName.length ∉ 100
 
 ### courseType (String)
-validCourseTypes := {"Lecture", "Seminar", "Project Group"}
-- vCourseType1: courseType $\in$ validCourseTypes
-- iCourseType1: courseType $\notin$ validCourseTypes
+*validCourseTypes* := {"Lecture", "Seminar", "Project Group"}
+- vCourseType1: courseType ∈ *validCourseTypes*
+- iCourseType1: courseType ∉ *validCourseTypes*
 
 ### startDate (String)
-$\textsf{validDates} := \{"1000-01-01", ..., "9999-12-31" | \textsf{ x is an existing date}\}$
-- vStartDate1: startDate $\in$ validDates
-- iStartDate1: startDate $\notin$ validDates BUT is of format YYYY-MM-DD
+*validDates* := {"1000-01-01", ..., "9999-12-31" | x is an existing date }
+- vStartDate1: startDate ∈ *validDates*
+- iStartDate1: startDate ∉ *validDates* BUT is of format YYYY-MM-DD
 - iStartDate2: startDate is not of the format YYYY-MM-DD
 
 ### endDate (String)
-- vEndDate1: endDate $\in$ validDates
-- iEndDate1: endDate $\notin$ validDates BUT is of format YYYY-MM-DD
+- vEndDate1: endDate ∈ *validDates*
+- iEndDate1: endDate ∉ *validDates* BUT is of format YYYY-MM-DD
 - iEndDate2: endDate is not of the format YYYY-MM-DD
 
 ### ects (Int)
-- vEcts1: ects $\in [1, 999]$
-- iEcts1: ects $\notin [1, 999]$
+- vEcts1: ects ∈ [1, 999]
+- iEcts1: ects ∉ [1, 999]
 
 ### lecturerId (String)
 No explicit validation.
 
 ### maxParticipants (Int)
-- vMaxParticipants1: maxParticipants $\in [1, 9999]$
-- iMaxParticipants1: maxParticipants $\notin [1, 9999]$
+- vMaxParticipants1: maxParticipants ∈ [1, 9999]
+- iMaxParticipants1: maxParticipants ∉ [1, 9999]
   
 ### currentParticipants (Int)
-- vCurrentParticipants1: currentParticipants $\in [0,$ maxParticipants$]$
-- iCurrentParticipants1: currentParticipants $\notin [0,$ maxParticipants$]$
+- vCurrentParticipants1: currentParticipants ∈ [0, maxParticipants]
+- iCurrentParticipants1: currentParticipants ∉ [0, maxParticipants]
 
 ### courseLanguage (String)
-$\textsf{validLanguages} := \{\textsf{"English"}, \textsf{"German"}\}$
-- vCourseLanguage1: courseLanguage $\in$ validLanguages
-- iCourseLanguage1: courseLanguage $\notin$ validLanguages
+*validLanguages* are "English" and "German"
+- vCourseLanguage1: courseLanguage ∈ *validLanguages*
+- iCourseLanguage1: courseLanguage ∉ *validLanguages*
 
 ### courseDescription (String)
-- vCourseDescription1: courseDescription.length $\in [0, 10000]$
-- iCourseDescription1: courseDescription.length $\notin [0, 10000]$
+- vCourseDescription1: courseDescription.length ∈ [0, 10000]
+- iCourseDescription1: courseDescription.length ∉ [0, 10000]

--- a/product_test/test_documentation/validation/matriculation-management.md
+++ b/product_test/test_documentation/validation/matriculation-management.md
@@ -1,20 +1,13 @@
 # MatriculationData Validation Tests
 Every invalid equivalence class returns an error. Every valid class returns an empty sequence.
 
-## AuthenticationUser
-$\textsf{validCharactersUsername} := \textsf{Letters} \cup \textsf{Digits} \cup \{\textsf{'-'}\}$
 ### fieldOfStudy (String)
-$\begin{aligned}\textsf{validFieldsOfStudies} := \{
-&\textsf{"Computer Science", "Philosophy", "Media Sciences", "Economics",}\\
-&\textsf{"Mathematics", "Physics","Chemistry", "Education", "Sports Science",}\\
-&\textsf{"Japanology", "Spanish Culture", "Pedagogy", "Business Informatics",}\\
-&\textsf{"Linguistics"}
-\}\end{aligned}$
-- vFieldOfStudy1: fieldOfStudy $\in$ validFieldsOfStudies
-- vFieldOfStudy1: fieldOfStudy $\notin$ validFieldsOfStudies
+*validFieldsOfStudies* := {"Computer Science", "Philosophy", "Media Sciences", "Economics", "Mathematics", "Physics","Chemistry", "Education", "Sports Science", "Japanology", "Spanish Culture", "Pedagogy", "Business Informatics", "Linguistics"}
+- vFieldOfStudy1: fieldOfStudy ∈ *validFieldsOfStudies*
+- vFieldOfStudy1: fieldOfStudy ∉ *validFieldsOfStudies*
 
 ### semester (String)
-$\textsf{Semesters} := \{\textsf{"SS1000"}, \textsf{"WS1000/01"}, ..., \textsf{"SS9998"}, \textsf{"WS9999/00"}\}$
-- vSemester1: latestImmatriculation $\in$ Semesters
-- vSemester2: latestImmatriculation is the empty String
-- iSemester1: latestImmatriculation $\neq$ "" AND latestImmatriculation $\notin$ Semesters
+Valid semesters are of the form "SS2016" and "WS2017/18"
+- vSemester1: semester is of a valid format for semesters
+- iSemester1: semester is the empty String
+- iSemester2: semester is not the empty String AND semester is not in a valid format for semesters

--- a/product_test/test_documentation/validation/user-management.md
+++ b/product_test/test_documentation/validation/user-management.md
@@ -4,80 +4,77 @@ Every invalid equivalence class returns an error. Every valid class returns an e
 ## Address
 
 ### Street (String)
-$\textsf{validCharactersStreet} := \textsf{Letters} \cup \textsf{Umlauts} \cup \{\textsf{'ß'}\} \cup \textsf{Digits} \cup \textsf{Whitespace} \cup \{\textsf{'.', ',', '-'}\}$
-- vStreet1: street.length $\in$ [1,50] AND street has only characters defined in $\textsf{validCharactersStreet}$
-- iStreet1: street.length $\notin$ [1,50] 
-- iStreet2: street contains characters not defined in $\textsf{validCharactersStreet}$
+*validCharactersStreet* := Letters ∪ Umlauts ∪ Digits ∪ Whitespace ∪ {ß , .  -}
+- vStreet1: street.length ∈ [1, 50] AND street has only valid characters
+- iStreet1: street.length ∉ [1, 50] 
+- iStreet2: street contains characters not defined in *validCharactersStreet*
 
 ### houseNumber (String)
-$\textsf{Formats} := \textsf{\{"XX", "XXY", "XXY-Y" | X is a number, Y is a letter\}}$
-- vHouseNumber1: houseNumber is of one of the formats given in Formats
+Valid house numbers are of the form "42", "42b", and "53a-c". Letters may be lower- or uppercase.
+- vHouseNumber1: houseNumber is of one of the valid formats
 - iHouseNumber1: houseNumber is the empty String
-- iHouseNumber2: houseNumber has leading zero BUT is of one of the formats given in Formats
-- iHouseNumber3: houseNumber is not of one of the formats given in Formats
+- iHouseNumber2: houseNumber has leading zero BUT is of one of a valid formats
+- iHouseNumber3: houseNumber is not of one of the valid formats
 
 ### zipCode (String)
 - vZipCode1: zipCode is number with exactly five digits
 - iZipCode1: zipCode is a number with more or less than five digits
 - iZipCode2: zipCode is not a number
 
-
 ### city (String)
-$\textsf{validCharactersCity} := \textsf{Letters} \cup \textsf{Umlauts} \cup \{\textsf{'ß'}\} \cup \textsf{Digits} \cup \textsf{Whitespace} \cup \{\textsf{'.', ',', '-'}\}$
-- vCity1: city.length $\in$ [1,50] AND city has only characters defined in $\textsf{validCharactersCity}$
-- iCity1: city.length $\notin$ [1,50] 
-- iCity2: city contains characters not defined in $\textsf{validCharactersCity}$
+*validCharactersCity* := Letters ∪ Umlauts ∪ {'ß'} ∪ Digits ∪ Whitespace ∪ {'.', ',', '-'}
+- vCity1: city.length ∈ [1,50] AND city has only characters defined in *validCharactersCity*
+- iCity1: city.length ∉ [1,50] 
+- iCity2: city contains characters not defined in *validCharactersCity*
 
 ### country (String)
-$\begin{aligned} \textsf{Countries} :=\{&\textsf{"Germany", "United States", "Italy", "France", "United Kingdom", "Belgium",} \\
-&\textsf{"Netherlands","Spain","Austria", "Switzerland", "Poland"}\}
- \end{aligned}$
+*Countries* := {"Germany", "United States", "Italy", "France", "United Kingdom", "Belgium", "Netherlands","Spain","Austria", "Switzerland", "Poland"}
 
-- vCountry1: country $\in$ Countries
-- iCountry1: country $\notin$ Countries
+- vCountry1: country ∈ Countries
+- iCountry1: country ∉ Countries
 
 ## User
-$\textsf{validCharactersUsername} := \textsf{Letters} \cup \textsf{Digits} \cup \{\textsf{'-'}\}$
+*validCharactersUsername* := Letters ∪ Digits ∪ {'-'}
 ### username (String)
-- vUsername1: username.length $\in$ [4,16] AND username has only characters defined in $\textsf{validCharactersUsername}$
-- iUsername1: username.length $\notin$ [4,16]
-- iUsername2: username contains characters not defined in $\textsf{validCharactersUsername}$'
+- vUsername1: username.length ∈ [4,16] AND username has only characters defined in *validCharactersUsername*
+- iUsername1: username.length ∉ [4,16]
+- iUsername2: username contains characters not defined in *validCharactersUsername*
 
 ### role (Enum[Role])
-$\textsf{Roles} := \{"\textsf{Student}", "\textsf{Lecturer}", "\textsf{Admin"}\}$
-- vRole1: role $\in$ Roles AND role conforms to type of object
-- iRole1: role $\in$ Roles BUT role does not conform to type of object
-- iRole2: role $\notin$ Roles
+*Roles* := {"Student", "Lecturer", "Admin"}
+- vRole1: role ∈ *Roles* AND role conforms to type of object
+- iRole1: role ∈ *Roles* BUT role does not conform to type of object
+- iRole2: role ∉ *Roles*
 
 ### address (Address)
 Address equivalance classes defined as above.
 
 ### firstName (String)
-- vFirstName1: firstName.length $\in$ [1,100]
-- iFirstName1: firstName.length $\notin$ [1,100]
+- vFirstName1: firstName.length ∈ [1,100]
+- iFirstName1: firstName.length ∉ [1,100]
 
 ### lastName (String)
-- vLastName1: lastName.length $\in$ [1,100]
-- iLastName1: lastName.length $\notin$ [1,100]
+- vLastName1: lastName.length ∈ [1,100]
+- iLastName1: lastName.length ∉ [1,100]
 
 ### picture (String)
-- vPicture1: picture.length $\leq$ 200
-- iPicture1: picture.length $>$ 200
+- vPicture1: picture.length ≤ 200
+- iPicture1: picture.length > 200
 
 ### email (String)
 - vEmail1: email is of the correct E-Mail format ("example@mail.com")
 - iEmail1: email is not of the correct E-Mail format 
 
 ### phoneNumber (String)
-- vPhoneNumber1: phoneNumber has a 1 to 30 digits and a leading '+'
+- vPhoneNumber1: phoneNumber has 1 to 30 digits and a leading '+'
 - iPhoneNumber1: phoneNumber contains symbols other than digits after the '+'
 - iPhoneNumber2: phoneNumber is missing the leading '+'
-- iPhoneNumber3: phoneNumber.length $\notin$ [2,31]
+- iPhoneNumber3: phoneNumber.length ∉ [2, 31]
 
 ### birthDate (String)
-$\textsf{validBirthdates} := \{"1000-01-01", ..., "9999-12-31" | \textsf{ x is an existing date}\}$
-- vBirthDate1: birthDate $\in$ validBirthdates
-- iBirthDate1: birthDate $\notin$ validBirthdates BUT is of format YYYY-MM-DD
+*validBirthdates* := {"1000-01-01", ..., "9999-12-31" | x is an existing date }
+- vBirthDate1: birthDate ∈ *validBirthdates*
+- iBirthDate1: birthDate ∉ *validBirthdates* BUT is of format YYYY-MM-DD
 - iBirthDate2: birthDate is not of the format YYYY-MM-DD
 
 ## Admin
@@ -87,24 +84,24 @@ Extends User, and inherits parameters as such. No additional parameters.
 Extends User, and inherits parameters as such. Additional parameters:
 
 ### freeText (String)
-- vFreeText1: freeText.length $\leq$ 10000
-- iFreeText1: freeText.length $>$ 10000
+- vFreeText1: freeText.length ≤ 10000
+- iFreeText1: freeText.length > 10000
 
 ### reserachArea (String)
-- vResearchArea1: researchArea.length $\leq$ 200
-- iResearchArea1: researchArea.length $>$ 200
+- vResearchArea1: researchArea.length ≤ 200
+- iResearchArea1: researchArea.length > 200
 
 ## Student
 Extends User, and inherits parameters as such. Additional parameters:
 
 ### latestImmatriculation (String)
-$\textsf{Semesters} := \{\textsf{"SS1000"}, \textsf{"WS1000/01"}, ..., \textsf{"SS9998"}, \textsf{"WS9999/00"}\}$
-- vLatestImmatriculation1: latestImmatriculation $\in$ Semesters
-- vLatestImmatriculation2: latestImmatriculation is the empty String
-- iLatestImmatriculation1: latestImmatriculation $\neq$ "" AND latestImmatriculation $\notin$ Semesters
+Valid semesters are of the form "SS2016" and "WS2017/18"
+- vSemester1: latestImmatriculation in valid format for semesters
+- vSemester2: latestImmatriculation is the empty String
+- iSemester1: latestImmatriculation is not the empty String AND latestImmatriculation is not in valid format for semesters
 
 ### matriculationId (String)
-$\textsf{MatriculationIds} := \{0000001, 0000002, ..., 9999999\}$
-- vMatriculationId1: matriculationId $\in$ MatriculationIds
-- iMatriculationId1: matriculationId $\notin$ MatriculationIds AND matriculationId.length $=$ 7
-- iMatriculationId2: matriculationId.length $\neq$ 7
+*validMatriculationIds* := {0000001, 0000002, ..., 9999999}
+- vMatriculationId1: matriculationId ∈ *validMatriculationIds*
+- iMatriculationId1: matriculationId ∉ *validMatriculationIds* AND matriculationId.length = 7
+- iMatriculationId2: matriculationId.length ≠ 7

--- a/product_test/test_documentation/validation/user-management.md
+++ b/product_test/test_documentation/validation/user-management.md
@@ -30,8 +30,8 @@ Valid house numbers are of the form "42", "42b", and "53a-c". Letters may be low
 ### country (String)
 *Countries* := {"Germany", "United States", "Italy", "France", "United Kingdom", "Belgium", "Netherlands","Spain","Austria", "Switzerland", "Poland"}
 
-- vCountry1: country ∈ Countries
-- iCountry1: country ∉ Countries
+- vCountry1: country ∈ *Countries*
+- iCountry1: country ∉ *Countries*
 
 ## User
 *validCharactersUsername* := Letters ∪ Digits ∪ {'-'}

--- a/product_test/test_documentation/validation/user-management.md
+++ b/product_test/test_documentation/validation/user-management.md
@@ -62,7 +62,7 @@ Address equivalance classes defined as above.
 - iPicture1: picture.length > 200
 
 ### email (String)
-- vEmail1: email is of the correct E-Mail format ("example@mail.com")
+- vEmail1: email is of the correct E-Mail format ("<span>example@mail.</span>com")
 - iEmail1: email is not of the correct E-Mail format 
 
 ### phoneNumber (String)


### PR DESCRIPTION
### Reason for this PR
- Github does not properly display LaTeX in markdown

### Changes in this PR
- Remove LaTeX from all markdown files in validation
- Fixed #225 