### PR TITLE
Feature/move test data

### DIFF
--- a/product_code/authentication_service/api/src/test/scala/de/upb/cs/uc4/authentication/AuthenticationServiceStub.scala
+++ b/product_code/authentication_service/api/src/test/scala/de/upb/cs/uc4/authentication/AuthenticationServiceStub.scala
@@ -1,4 +1,4 @@
-package de.upb.cs.uc4.authentication.test
+package de.upb.cs.uc4.authentication
 
 import akka.{ Done, NotUsed }
 import com.lightbend.lagom.scaladsl.api.ServiceCall

--- a/product_code/authentication_service/api/src/test/scala/de/upb/cs/uc4/authentication/DefaultTestAuthenticationUsers.scala
+++ b/product_code/authentication_service/api/src/test/scala/de/upb/cs/uc4/authentication/DefaultTestAuthenticationUsers.scala
@@ -1,4 +1,4 @@
-package de.upb.cs.uc4.authentication.test
+package de.upb.cs.uc4.authentication
 
 import de.upb.cs.uc4.authentication.model.{ AuthenticationRole, AuthenticationUser }
 

--- a/product_code/authentication_service/impl/src/test/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceSpec.scala
+++ b/product_code/authentication_service/impl/src/test/scala/de/upb/cs/uc4/authentication/impl/AuthenticationServiceSpec.scala
@@ -11,9 +11,9 @@ import de.upb.cs.uc4.authentication.api.AuthenticationService
 import de.upb.cs.uc4.authentication.model.{ AuthenticationRole, AuthenticationUser }
 import de.upb.cs.uc4.shared.client.exceptions.CustomException
 import de.upb.cs.uc4.shared.server.ServiceCallFactory
+import de.upb.cs.uc4.user.UserServiceStub
 import de.upb.cs.uc4.user.api.UserService
 import de.upb.cs.uc4.user.model.JsonUsername
-import de.upb.cs.uc4.user.test.UserServiceStub
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.matchers.should.Matchers

--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -135,7 +135,7 @@ lazy val course_service = (project in file("course_service/impl"))
   .settings(commonSettings("course_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.0")
-  .dependsOn(course_service_api, shared_server)
+  .dependsOn(course_service_api, authentication_service_api % "compile->compile;test->test", shared_server)
 
 lazy val authentication_service_api = (project in file("authentication_service/api"))
   .settings(
@@ -153,7 +153,7 @@ lazy val authentication_service = (project in file("authentication_service/impl"
   .settings(commonSettings("authentication_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.0")
-  .dependsOn(authentication_service_api, user_service_api, shared_server)
+  .dependsOn(authentication_service_api, user_service_api % "compile->compile;test->test", shared_server)
 
 lazy val user_service_api = (project in file("user_service/api"))
   .settings(
@@ -171,7 +171,7 @@ lazy val user_service = (project in file("user_service/impl"))
   .settings(commonSettings("user_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.1")
-  .dependsOn(user_service_api, shared_server, shared_client)
+  .dependsOn(user_service_api % "compile->compile;test->test", authentication_service_api % "compile->compile;test->test", shared_server, shared_client)
 
 lazy val matriculation_service_api = (project in file("matriculation_service/api"))
   .settings(
@@ -189,4 +189,4 @@ lazy val matriculation_service = (project in file("matriculation_service/impl"))
   .settings(commonSettings("matriculation_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.0")
-  .dependsOn(user_service_api, shared_server, shared_client, matriculation_service_api, hyperledger_component)
+  .dependsOn(user_service_api % "compile->compile;test->test", authentication_service_api % "compile->compile;test->test", shared_server, shared_client, matriculation_service_api, hyperledger_component)

--- a/product_code/build.sbt
+++ b/product_code/build.sbt
@@ -17,6 +17,8 @@ def commonSettings(project: String) = Seq(
   testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test_reports/" + project)
 )
 
+val withTests = "compile->compile;test->test"
+
 // Docker
 val dockerSettings = Seq(
   dockerUpdateLatest := true,
@@ -135,7 +137,7 @@ lazy val course_service = (project in file("course_service/impl"))
   .settings(commonSettings("course_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.0")
-  .dependsOn(course_service_api, authentication_service_api % "compile->compile;test->test", shared_server)
+  .dependsOn(course_service_api, authentication_service_api % withTests, shared_server)
 
 lazy val authentication_service_api = (project in file("authentication_service/api"))
   .settings(
@@ -153,7 +155,7 @@ lazy val authentication_service = (project in file("authentication_service/impl"
   .settings(commonSettings("authentication_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.0")
-  .dependsOn(authentication_service_api, user_service_api % "compile->compile;test->test", shared_server)
+  .dependsOn(authentication_service_api, user_service_api % withTests, shared_server)
 
 lazy val user_service_api = (project in file("user_service/api"))
   .settings(
@@ -171,7 +173,7 @@ lazy val user_service = (project in file("user_service/impl"))
   .settings(commonSettings("user_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.1")
-  .dependsOn(user_service_api % "compile->compile;test->test", authentication_service_api % "compile->compile;test->test", shared_server, shared_client)
+  .dependsOn(user_service_api % withTests, authentication_service_api % withTests, shared_server, shared_client)
 
 lazy val matriculation_service_api = (project in file("matriculation_service/api"))
   .settings(
@@ -189,4 +191,4 @@ lazy val matriculation_service = (project in file("matriculation_service/impl"))
   .settings(commonSettings("matriculation_service"))
   .settings(dockerSettings)
   .settings(version := "v0.5.0")
-  .dependsOn(user_service_api % "compile->compile;test->test", authentication_service_api % "compile->compile;test->test", shared_server, shared_client, matriculation_service_api, hyperledger_component)
+  .dependsOn(user_service_api % withTests, authentication_service_api % withTests, shared_server, shared_client, matriculation_service_api, hyperledger_component)

--- a/product_code/course_service/impl/src/test/scala/de/upb/cs/uc4/course/impl/CourseServiceSpec.scala
+++ b/product_code/course_service/impl/src/test/scala/de/upb/cs/uc4/course/impl/CourseServiceSpec.scala
@@ -6,8 +6,8 @@ import akka.Done
 import com.lightbend.lagom.scaladsl.api.transport.RequestHeader
 import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
 import com.lightbend.lagom.scaladsl.testkit.ServiceTest
+import de.upb.cs.uc4.authentication.AuthenticationServiceStub
 import de.upb.cs.uc4.authentication.api.AuthenticationService
-import de.upb.cs.uc4.authentication.test.AuthenticationServiceStub
 import de.upb.cs.uc4.course.api.CourseService
 import de.upb.cs.uc4.course.model.{ Course, CourseLanguage, CourseType }
 import de.upb.cs.uc4.shared.client.exceptions.CustomException

--- a/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
+++ b/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
@@ -5,14 +5,15 @@ import java.util.Base64
 import com.lightbend.lagom.scaladsl.api.transport.RequestHeader
 import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
 import com.lightbend.lagom.scaladsl.testkit.ServiceTest
+import de.upb.cs.uc4.authentication.AuthenticationServiceStub
 import de.upb.cs.uc4.authentication.api.AuthenticationService
-import de.upb.cs.uc4.authentication.test.AuthenticationServiceStub
 import de.upb.cs.uc4.hyperledger.connections.traits.ConnectionMatriculationTrait
 import de.upb.cs.uc4.hyperledger.exceptions.traits.TransactionExceptionTrait
 import de.upb.cs.uc4.matriculation.api.MatriculationService
 import de.upb.cs.uc4.matriculation.impl.actor.MatriculationBehaviour
 import de.upb.cs.uc4.matriculation.model.{ ImmatriculationData, PutMessageMatriculationData, SubjectMatriculation }
-import de.upb.cs.uc4.user.test.{ DefaultTestUsers, UserServiceStub }
+import de.upb.cs.uc4.user.{ DefaultTestUsers, UserServiceStub }
+import de.upb.cs.uc4.user.test.UserServiceStub
 import org.hyperledger.fabric.gateway.{ Contract, Gateway }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
+++ b/product_code/matriculation_service/impl/src/test/scala/de/upb/cs/uc4/matriculation/impl/MatriculationServiceSpec.scala
@@ -13,7 +13,6 @@ import de.upb.cs.uc4.matriculation.api.MatriculationService
 import de.upb.cs.uc4.matriculation.impl.actor.MatriculationBehaviour
 import de.upb.cs.uc4.matriculation.model.{ ImmatriculationData, PutMessageMatriculationData, SubjectMatriculation }
 import de.upb.cs.uc4.user.{ DefaultTestUsers, UserServiceStub }
-import de.upb.cs.uc4.user.test.UserServiceStub
 import org.hyperledger.fabric.gateway.{ Contract, Gateway }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers

--- a/product_code/user_service/api/src/test/scala/de/upb/cs/uc4/user/DefaultTestUsers.scala
+++ b/product_code/user_service/api/src/test/scala/de/upb/cs/uc4/user/DefaultTestUsers.scala
@@ -1,4 +1,4 @@
-package de.upb.cs.uc4.user.test
+package de.upb.cs.uc4.user
 
 import de.upb.cs.uc4.authentication.model.{ AuthenticationRole, AuthenticationUser }
 import de.upb.cs.uc4.user.model.user.{ Admin, Lecturer, Student }

--- a/product_code/user_service/api/src/test/scala/de/upb/cs/uc4/user/UserServiceStub.scala
+++ b/product_code/user_service/api/src/test/scala/de/upb/cs/uc4/user/UserServiceStub.scala
@@ -1,4 +1,4 @@
-package de.upb.cs.uc4.user.test
+package de.upb.cs.uc4.user
 
 import akka.{ Done, NotUsed }
 import com.lightbend.lagom.scaladsl.api.ServiceCall

--- a/product_code/user_service/impl/src/test/scala/de/upb/cs/uc4/user/impl/UserServiceSpec.scala
+++ b/product_code/user_service/impl/src/test/scala/de/upb/cs/uc4/user/impl/UserServiceSpec.scala
@@ -6,14 +6,14 @@ import akka.stream.scaladsl.Source
 import com.lightbend.lagom.scaladsl.api.transport.RequestHeader
 import com.lightbend.lagom.scaladsl.server.LocalServiceLocator
 import com.lightbend.lagom.scaladsl.testkit.{ ServiceTest, TestTopicComponents }
+import de.upb.cs.uc4.authentication.AuthenticationServiceStub
 import de.upb.cs.uc4.authentication.api.AuthenticationService
-import de.upb.cs.uc4.authentication.test.AuthenticationServiceStub
 import de.upb.cs.uc4.shared.client.exceptions.{ CustomException, DetailedError }
+import de.upb.cs.uc4.user.DefaultTestUsers
 import de.upb.cs.uc4.user.api.UserService
 import de.upb.cs.uc4.user.model.post.{ PostMessageAdmin, PostMessageLecturer, PostMessageStudent }
 import de.upb.cs.uc4.user.model.user.{ Lecturer, Student }
 import de.upb.cs.uc4.user.model.{ GetAllUsersResponse, JsonUsername, Role }
-import de.upb.cs.uc4.user.test.DefaultTestUsers
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.Eventually
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
### Reason for this PR
- The test stubs and standard users were in the regular api folder, not in the test folder

### Changes in this PR
- Moved test stubs and standard Users to the test folders
- Adjusted build.sbt to properly import test files from depended projects
